### PR TITLE
Added in the ability to be able to restrict tags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Features
 * Autocompletion
 * Mouse and keyboard handling
 * Visual integration into bootstrapped form environments
-* Allowing a strict limit of items you can tag.
+* Allowing a strict limit of items you can tag. *restricted:true*
 
 Requirements
 ------------
@@ -71,7 +71,8 @@ Control the `ul` element using jQuery:
     
         $("#languages-select").tagit({
             tags: tags,
-            field: "language"
+            field: "language",
+            restricted: false // Setting this to true will enable restricting of the tags to the previous tag field.
         });
     });
 </script>

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Features
 * Autocompletion
 * Mouse and keyboard handling
 * Visual integration into bootstrapped form environments
+* Allowing a strict limit of items you can tag.
 
 Requirements
 ------------

--- a/example/example2.html
+++ b/example/example2.html
@@ -1,0 +1,69 @@
+
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>jQuery.tagit example</title>
+        
+        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js"></script>
+        <script type="text/javascript" src="../lib/jquery.tagit.js"></script>
+        
+        <style type="text/css">
+            @import url('http://twitter.github.com/bootstrap/assets/css/bootstrap-1.1.1.min.css');
+            @import url('../css/tagit.css');
+            
+            #languages-select {
+                width: 530px;
+            }
+            
+            .body-content {
+                margin-top: 20px;
+                border-radius: 4px;
+                background: whitesmoke;
+                border: solid 1px #CCC;
+            }
+            
+            .body-content > div {
+                margin: 20px;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="container">
+            <div class="row">
+                <div class="span16 columns body-content">
+                    <div>
+                        <p>
+                            You can only add items in the tags option if "restricted" is true.
+                        </p>
+                        <form action="#">
+                            <fieldset>
+                                <div class="clearfix">
+                                    <label>Experience in</label>
+                                    <div class="input">
+                                        <ul id="languages-select" class="fake-input" tabindex="1">
+                                            <li>Java</li>
+                                        </ul>
+                                    </div>
+                                </div>
+                            </fieldset>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <script type="text/javascript">
+            
+            var tags = ["Java", "Javascript", "Python", "C", 
+                       "C++", "Ruby", "CSS", "HTML", "C#", 
+                       "Visual Basic", "Prolog", "Smalltalk", 
+                       "Scala", "Haskel", "Bash"];
+            
+            $("#languages-select").tagit({
+                tags: tags,
+                field: "language",
+                restricted: true
+            });
+            
+        </script>
+    </body>
+</html>

--- a/lib/jquery.tagit.js
+++ b/lib/jquery.tagit.js
@@ -77,6 +77,11 @@
             }
 
             var data = self.data("tagit");
+
+            // Add restrictions to only allow items in tags.
+            if((data.restricted) && ($.inArray(tag, data.tags) == -1)){
+                return;
+            }
             
             var hiddenInput = $('<input type="hidden"/>')
                                     .attr("name", data.field)
@@ -271,6 +276,7 @@
 
     $.fn.tagit.defaults = {
         field: "tag",
-        tags: []
+        tags: [],
+        restricted:false
     };
 })(jQuery);


### PR DESCRIPTION
I added in an option "restricted" that will disallow any new tags from being created. The project I am using this with only needs a few certain tags and I didn't want them to be spammed with unimportant tags. With restricted=true in the tagit(), it will return early and not allow the tag to be added if it is not existing in the permitted tag list.
